### PR TITLE
Initial database copy; unversion data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ docker_portainer_version: "1.11.1"
 docker_portainer_container_name: "portainer"
 docker_portainer_container_volume_base: "/opt/docker"
 docker_portainer_port: "9000"
+docker_portainer_initial_database_file: "files/portainer/portainer.db"
 ```
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 docker_portainer_state: "started"
-docker_portainer_version: "1.11.1"
+docker_portainer_version: "1.11.3"
 docker_portainer_container_name: "portainer"
 docker_portainer_container_volume_base: "/opt/docker"
 docker_portainer_port: "9000"
+docker_portainer_initial_database_file: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
     src: "{{ docker_portainer_initial_database_file }}"
     dest: "{{ docker_portainer_volume }}/data/portainer.db"
     mode: 0600
+    force: no
   when: "{{ docker_portainer_initial_database_file != '' }}"
 
 - name: install container

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,16 @@
 ---
 - name: set docker_portainer_volume
-  set_fact: docker_portainer_volume="{{docker_portainer_container_volume_base}}/{{docker_portainer_container_name}}-{{docker_portainer_version}}"
+  set_fact: docker_portainer_volume="{{docker_portainer_container_volume_base}}/{{docker_portainer_container_name}}"
 
 - name: create volume directory for data
   file: path={{docker_portainer_volume}}/data state=directory recurse=yes
+
+- name: initial database
+  copy:
+    src: "{{ docker_portainer_initial_database_file }}"
+    dest: "{{ docker_portainer_volume }}/data/portainer.db"
+    mode: 0600
+  when: "{{ docker_portainer_initial_database_file != '' }}"
 
 - name: install container
   docker_container:


### PR DESCRIPTION
I needed a default database to be deployed, so i introduce the "docker_portainer_initial_database_file" optional variable. (this database ican be used from a working portainer data volume)

I changed the upstream version.

I changed the directory of the data because I think the database should be kept between versions (by default).